### PR TITLE
Styles issues

### DIFF
--- a/app/assets/stylesheets/breeze/breeze_front_editor.sass
+++ b/app/assets/stylesheets/breeze/breeze_front_editor.sass
@@ -353,7 +353,7 @@ body.breeze-editing
     display: inline-block
     width: 16px
     height: 16px
-    background: #eeeeee url( image_path('breeze/marquess/marquess-toolbar.png')) no-repeat 0px -112px
+    background: #eeeeee url( image_path('breeze/marquess/marquess-toolbar.png') ) no-repeat 0px -112px
     border: 4px solid #eee
     text-indent: -100em
     overflow: hidden
@@ -575,3 +575,131 @@ body.breeze-editing
   bottom: 40px
   overflow: auto
   padding: 8px
+
+
+.marquess-container
+  background: #f2f2f2
+  border: 8px solid #f2f2f2
+  -webkit-border-radius: 8px
+  -webkit-box-shadow: rgba(0, 0, 0, 0.25) 0px 1px 4px
+  -moz-border-radius: 8px
+  -moz-box-shadow: rgba(0, 0, 0, 0.25) 0px 1px 4px
+
+.marquess-editor-pane, .marquess-preview-pane
+  clear: left
+  background: white
+
+.marquess-editor-pane
+  padding-right: 8px
+
+.marquess-editor
+  border: none
+  display: block
+  width: 100%
+  padding: 4px
+  background: white
+  font: 13px Monaco, Courier, monospace
+  resize: vertical
+
+.marquess-preview-pane
+  padding: 4px
+  border-top: 4px solid #f2f2f2
+
+.marquess-toolbar-row
+  margin: 0px 4px 4px 0px
+  padding: 0px 0px 0px 4px
+  height: 32px
+  background: #ccc
+  float: left
+  -webkit-border-radius: 4px
+  -moz-border-radius: 4px
+
+.marquess-toolbar li
+  margin: 0px
+  padding: 0px
+  list-style: none
+  display: inline
+  &.separator
+    display: block
+    float: left
+    width: 8px
+    height: 24px
+  a
+    float: left
+    position: relative
+    height: 22px
+    overflow: hidden
+    margin: 4px 4px 4px 0px
+    background: #eee
+    border: 1px solid #eee
+    text-decoration: none
+    font: 12px "Lucida Grande", Helvetica, Arial, sans-serif
+    line-height: 16px
+    vertical-align: middle
+    text-indent: -100em
+    color: #666
+    outline: none
+    -webkit-border-radius: 2px
+    -moz-border-radius: 2px
+    span
+      display: block
+      margin: 3px
+      padding: 0px
+      line-height: 16px
+      vertical-align: middle
+      width: 16px
+      background: transparent url( image_path('breeze/marquess/marquess-toolbar.png') ) no-repeat 0px 0px
+    &.with-title span
+      width: auto
+      overflow: visible
+      text-indent: 0px
+      padding-left: 22px
+    &:hover
+      border-color: #999
+      text-shadow: white 0px 1px 1px
+      -webkit-box-shadow: inset white 0px 1px 4px, inset rgba(0, 0, 0, 0.25) 0px -1px 4px
+      -moz-box-shadow: inset white 0px 1px 4px, inset rgba(0, 0, 0, 0.25) 0px -1px 4px
+    &:active
+      -webkit-box-shadow: inset white 0px -1px 4px, inset rgba(0, 0, 0, 0.25) 0px 1px 4px
+      -moz-box-shadow: inset white 0px -1px 4px, inset rgba(0, 0, 0, 0.25) 0px 1px 4px
+    &.active
+      -webkit-box-shadow: inset white 0px -1px 4px, inset rgba(0, 0, 0, 0.25) 0px 1px 4px
+      -moz-box-shadow: inset white 0px -1px 4px, inset rgba(0, 0, 0, 0.25) 0px 1px 4px
+      border-color: #999
+    &:active span
+      margin: 4px 3px 2px
+    &.bold span
+      background-position: 0px    0px
+    &.italic span
+      background-position: 0px -16px
+    &.heading span
+      background-position: 0px -32px
+    &.bulleted_list span
+      background-position: 0px -48px
+    &.numbered_list span
+      background-position: 0px -64px
+    &.blockquote span
+      background-position: 0px -80px
+    &.link span
+      background-position: 0px -96px
+    &.image span
+      background-position: 0px -112px
+    &.cut span
+      background-position: 0px -128px
+    &.copy span
+      background-position: 0px -144px
+    &.paste span
+      background-position: 0px -160px
+    &.undo span
+      background-position: 0px -176px
+    &.redo span
+      background-position: 0px -192px
+    &.preview span
+      background-position: 0px -208px
+    &.update span
+      background-position: 0px -224px
+    &.disabled
+      opacity: 0.25
+      border-color: #eee
+      -webkit-box-shadow: none
+      -moz-box-shadow: none

--- a/app/views/layouts/page.html.erb
+++ b/app/views/layouts/page.html.erb
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title><%= page.title %></title>
+    <%= javascript_include_tag "breeze/breeze" %>
+    <%= stylesheet_link_tag "breeze/breeze" %>
   </head>
 
   <body>


### PR DESCRIPTION
A couple of small commits to fix some issues arising from the Great Renaming of asset files:
1. Restored access to Marquess styles by moving them into breeze_front_editor.sass
2. Added tags to the default page.html view for the JS and CSS manifest files, to ensure that jQuery loads on a fresh page with no theme overrides.
