### PR TITLE
Fixes compatibility issue with Breeze Commerce checkout pages

### DIFF
--- a/app/helpers/breeze/contents_helper.rb
+++ b/app/helpers/breeze/contents_helper.rb
@@ -144,7 +144,7 @@ module Breeze
       # If there are no arguments, use the current page
       args.unshift page if args.empty? && !page.nil?
  
-      current_page = page
+      current_page = (defined? page) ? page : nil
       
       contents = "".tap do |str|
 


### PR DESCRIPTION
A one-line patch to contents_helper to allow the special checkout pages in Breeze Commerce to display navigation menus.

Both contents_helper and Breeze Commerce need significant refactoring, so this is a short-term fix.
