### PR TITLE
Removed duplicate gem dependency

### DIFF
--- a/breeze.gemspec
+++ b/breeze.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fabrication"
   
   s.add_dependency "rails", "~> 3.2.0"
-  s.add_dependency "jquery-rails"
   s.add_dependency "mongoid", "~> 3.0.5"
   s.add_dependency "carrierwave", "~> 0.6.2"
   s.add_dependency "carrierwave-mongoid", "~> 0.1.0"

--- a/breeze.gemspec
+++ b/breeze.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "haml", "3.1.7"
   s.add_dependency "coffee-script"
   s.add_dependency "jquery-fileupload-rails", "~> 0.4.0"
-  s.add_dependency "twitter-bootstrap-rails", "~> 2.2.0"
+  s.add_dependency "twitter-bootstrap-rails", "2.2.1"
   s.add_dependency "masonry-rails", "~> 0.1.8"
   s.add_dependency "codemirror-rails", "~> 3.0.0"
 end


### PR DESCRIPTION
The gemspec had two lines for jquery-rails:

  s.add_dependency "jquery-rails"
  s.add_dependency "jquery-rails", "~> 2.1.2"

Since jquery-rails is now on 2.2.x, this meant bundler always complained of incompatible versions.
