### PR TITLE
Fixes #19, plus other stuff.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       rdiscount (~> 1.6.8)
       rmagick (~> 2.13.1)
       therubyracer (~> 0.10.2)
-      twitter-bootstrap-rails (~> 2.2.0)
+      twitter-bootstrap-rails (= 2.2.1)
       will_paginate (= 3.0.pre4)
 
 GEM
@@ -146,7 +146,7 @@ GEM
     mime-types (1.21)
     mocha (0.10.5)
       metaclass (~> 0.0.1)
-    mongoid (3.0.21)
+    mongoid (3.0.22)
       activemodel (~> 3.1)
       moped (~> 1.2)
       origin (~> 1.0)
@@ -239,7 +239,7 @@ GEM
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
-    twitter-bootstrap-rails (2.2.3)
+    twitter-bootstrap-rails (2.2.1)
       actionpack (>= 3.1)
       execjs
       railties (>= 3.1)

--- a/app/assets/stylesheets/breeze/breeze_admin.sass
+++ b/app/assets/stylesheets/breeze/breeze_admin.sass
@@ -1,12 +1,12 @@
 @import "variables"
 @import "mixins"
 
-h1, h2, h3, h4, h5, h6
-  margin: 0
-
 /* Layout {{{
 
 body.breeze-admin
+  h1, h2, h3, h4, h5, h6
+    margin: 0
+
   margin: 0px
   padding: 0px
   background: #ddd

--- a/app/models/breeze/content/custom/type.rb
+++ b/app/models/breeze/content/custom/type.rb
@@ -56,7 +56,9 @@ module Breeze
           self.class.get(type_name)
         end
         
-        delegate :default_template_name, :to => :to_class
+        def default_template_name
+          name.squish.downcase.gsub(" ", "_")
+        end
       
         def self.get(type_name)
           @classes ||= {}

--- a/app/models/breeze/content/mixins/tree_structure.rb
+++ b/app/models/breeze/content/mixins/tree_structure.rb
@@ -81,35 +81,33 @@ module Breeze
 
         def set_position
           self.position = scope.count if ( self.position == 0 && ( self.position_changed? || self.parent_id_changed? ) )
-          update_sibling_positions 1, self.position
+          update_sibling_positions
         end
         
         def destroy_children
           children.map(&:destroy)
         end
         
-        # Increment the position number for siblings to make room for a new item
-        def update_sibling_positions(by = 1, ref_position=self.position)
-          base_class.where(:parent_id => parent_id, :position => { '$gte' => ref_position }).inc(:position, by)
+        def update_sibling_positions(ref_position=self.position)
+          siblings.where(:parent_id => parent_id, :position => { '$gte' => ref_position }).inc(:position, 1)
         end
         
-        def move_before!(node)
-          self.parent_id = node.parent_id
-          self.position = node.position 
-          update_sibling_positions(node.position + 1)
+        def move_before!(target)
+          self.parent_id = target.parent_id
+          self.position = target.position 
           save
         end
         
-        def move_after!(node)
-          self.parent_id = node.parent_id
-          self.position = node.position + 1
-          update_sibling_positions node.next.position if node.next
+        def move_after!(target)
+          self.parent_id = target.parent_id
+          self.position = target.position + 1
+          update_sibling_positions target.next.position if target.next
           save
         end
         
-        def move_inside!(node)
-          self.parent_id = node.id
-          self.position = base_class.criteria.where(:parent_id => node.id).count
+        def move_inside!(target)
+          self.parent_id = target.id
+          self.position = base_class.criteria.where(:parent_id => target.id).count
           save
         end
       end

--- a/app/views/breeze/admin/contents/edit.html.erb
+++ b/app/views/breeze/admin/contents/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="edit-content-tabs ui-tabs ui-widget ui-widget-content ui-corner-all">
-  <h2>Edit <%= @content.class.label %></h2>
+  <h2>Edit <%= @content.class.ancestors.include?(Breeze::Content::Custom::Instance) ? @content.class.custom_type.name : @content.class.label %></h2>
 
   <div id="edit-existing-content">
     <%= breeze_form_for @content, :as => :content, :url => admin_content_path(@placement.id, :format => :js), :remote => true do |form| %>

--- a/lib/breeze/admin/form_builder.rb
+++ b/lib/breeze/admin/form_builder.rb
@@ -84,7 +84,7 @@ module Breeze
           end.sort_by(&:first).collect do |group_label, classes|
             str << "<optgroup label=\"#{group_label}\">"
             classes.each do |c|
-              str << "<option value=\"#{c.to_s}\"#{' selected="selected"' if c == @object.class}>#{c.label}</option>"
+              str << "<option value=\"#{c.to_s}\"#{' selected="selected"' if c == @object.class}>#{c.ancestors.include?(Breeze::Content::Custom::Instance) ? c.custom_type.name : c.label}</option>"
             end
             str << "</optgroup>"
           end

--- a/spec/models/breeze/content/custom/type_spec.rb
+++ b/spec/models/breeze/content/custom/type_spec.rb
@@ -30,7 +30,7 @@ describe Breeze::Content::Custom::Type do
   it "exposes a default template name" do
     subject.name = 'custom_type_1'
     subject.save
-    subject.default_template_name.should eq('custom_type1')
+    subject.default_template_name.should eq('custom_type_1')
   end
 
 end

--- a/spec/models/breeze/content/mixins/tree_structure_spec.rb
+++ b/spec/models/breeze/content/mixins/tree_structure_spec.rb
@@ -28,15 +28,15 @@ describe "TreeStructure" do
   	before :each do
   		subject
   		target
-  		subject.position = 2
-  		subject.save
+  		target.position = 2
+  		target.save
  			subject.move!(:before, target.id)
   	end
   	# it "has same parent as target" do
  		# 	subject.parent.should eq target.parent
   	# end
   	it "has position immediately before target's position" do
-			target.reload
+      target.reload
 			subject.position.should eq ( target.position - 1 )
   	end
   	# it "calls update_sibling_position with the correct ref_position"


### PR DESCRIPTION
Fixed scope for admin header styles
Changed default template name for custom types to use name instead of
class name. This means designers don't have to keep using partials with
the original custom type name.
Changed front-end editing to use custom type name instead of class
Fixed broken move_before! method in tree_structure
